### PR TITLE
Fix TinyMCE editing and saving

### DIFF
--- a/tinymce/mavo-tinymce.js
+++ b/tinymce/mavo-tinymce.js
@@ -49,7 +49,7 @@ Mavo.Elements.register(".tinymce", {
 		if (!this.tinymce) {
 			element.innerHTML = content;
 		}
-		else {
+		else if (this.tinymce.isHidden()) {
 			this.tinymce.setContent(content);
 		}
 	}

--- a/tinymce/mavo-tinymce.js
+++ b/tinymce/mavo-tinymce.js
@@ -41,8 +41,18 @@ Mavo.Elements.register(".tinymce", {
 			tinymce.EditorManager.execCommand("mceRemoveEditor", true, this.tinymce.id);
 		}
 	},
-	getValue: element => element.innerHTML,
-	setValue: (element, value) => element.innerHTML = serializer.serialize(parser.parse(value))
+	getValue: function (element) {
+		return this.tinymce ? this.tinymce.getContent() : element.innerHTML;
+	},
+	setValue: function (element, value) {
+		const content = serializer.serialize(parser.parse(value));
+		if (!this.tinymce) {
+			element.innerHTML = content;
+		}
+		else {
+			this.tinymce.setContent(content);
+		}
+	}
 });
 
 })(Bliss);


### PR DESCRIPTION
This pull request provides solutions for #17 and #18.

I found out #18 happened because `setValue` is called after the first keystroke. The `if` I added in a6399f02f798ffde1d6dd597b29cabc5288d1d17 fixes this, but maybe `setValue` shouldn't be called in the first place.