### PR TITLE
Detect all TinyMCE changes

### DIFF
--- a/tinymce/mavo-tinymce.js
+++ b/tinymce/mavo-tinymce.js
@@ -14,9 +14,9 @@ Mavo.Elements.register(".tinymce", {
 	default: true,
 	edit: function() {
 		this.preEdit.then(evt => {
-			if (this.tinymce) {
+			if (this.element.tinymce) {
 				// Previously edited, we already have an editor
-				tinymce.EditorManager.execCommand("mceAddEditor", true, this.tinymce.id);
+				tinymce.EditorManager.execCommand("mceAddEditor", true, this.element.tinymce.id);
 				return;
 			}
 
@@ -28,9 +28,9 @@ Mavo.Elements.register(".tinymce", {
 				toolbar: "styleselect | bold italic | image link | table | bullist numlist",
 				plugins: "image code link table lists media tabfocus"
 			}).then(editors => {
-				this.tinymce = editors[0];
+				this.element.tinymce = editors[0];
 
-				this.tinymce.on("change", evt => {
+				this.element.tinymce.on("change", evt => {
 					this.value = this.getValue();
 				});
 			});
@@ -41,16 +41,16 @@ Mavo.Elements.register(".tinymce", {
 			tinymce.EditorManager.execCommand("mceRemoveEditor", true, this.tinymce.id);
 		}
 	},
-	getValue: function (element) {
-		return this.tinymce ? this.tinymce.getContent() : element.innerHTML;
+	getValue: (element) => {
+		return element.tinymce ? element.tinymce.getContent() : element.innerHTML;
 	},
-	setValue: function (element, value) {
+	setValue: (element, value) => {
 		const content = serializer.serialize(parser.parse(value));
-		if (!this.tinymce) {
+		if (!element.tinymce) {
 			element.innerHTML = content;
 		}
-		else if (this.tinymce.isHidden()) {
-			this.tinymce.setContent(content);
+		else if (element.tinymce.isHidden()) {
+			element.tinymce.setContent(content);
 		}
 	}
 });

--- a/tinymce/mavo-tinymce.js
+++ b/tinymce/mavo-tinymce.js
@@ -30,7 +30,7 @@ Mavo.Elements.register(".tinymce", {
 			}).then(editors => {
 				this.element.tinymce = editors[0];
 
-				this.element.tinymce.on("change", evt => {
+				this.element.tinymce.on("change keyup paste cut", evt => {
 					this.value = this.getValue();
 				});
 			});


### PR DESCRIPTION
Further testing revealed that #19 does not fix all cases.

I've created a [video](https://youtu.be/lzVu4dlsHLQ) that catches how TinyMCE sometimes fails to emit a `change` event, leading to incomplete data being saved by Mavo (the code in the video is [this branch](https://github.com/RubenVerborgh/plugins/tree/debug/tinymce-logging)). By listening to additional events, we can mitigate this problem. Furthermore, we fix the case where the user saves with a keyboard shortcut (which does not fire a `blur` event) rather than clicking the save button.

In an ideal world, listening to one event would be enough. Yet this does not seem to be how TinyMCE works, unfortunately. (Its `change` event is raised when a new undo level is created, and this does not always occur when Mavo needs it.)

Note that the `tinymce.getContent` introduced by #19 is still necessary: without it, on some occasions, TinyMCE internal data is saved (such as cursor position). However, the wrong `this` pointer used in #19 needed a fix (see https://github.com/mavoweb/mavo/issues/261).