### PR TITLE
Suggested edits to data

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -52,6 +52,16 @@
 			"author": "leaverou"
 		},
 		{
+			"name": "Firebase Firestore",
+			"id": "firebase-firestore",
+			"description": "Store and sync app data in milliseconds. Store and serve files at Google scale. Authenticate users simply and securely.\nAll the [Google Firebase](https://firebase.google.com/) powers are at your fingertips.",
+			"tag": [
+				"Backend"
+			],
+			"repo": "DmitrySharabin/mavo-firebase-firestore",
+			"author": "dmitrysharabin"
+		},
+		{
 			"name": "Google Drive",
 			"id": "gdrive",
 			"description": "Store and read data from Google Drive.",
@@ -188,16 +198,6 @@
 				"Editing"
 			],
 			"repo": "DmitrySharabin/mavo-math",
-			"author": "dmitrysharabin"
-		},
-		{
-			"name": "Firebase Firestore",
-			"id": "firebase-firestore",
-			"description": "Store and sync app data in milliseconds. Store and serve files at Google scale. Authenticate users simply and securely.\nAll the [Google Firebase](https://firebase.google.com/) powers are at your fingertips.",
-			"tag": [
-				"Backend"
-			],
-			"repo": "DmitrySharabin/mavo-firebase-firestore",
 			"author": "dmitrysharabin"
 		}
 	]


### PR DESCRIPTION
Hello there! I used Mavo to suggest the following edits:
I believe the Firebase Firestore plugin is production-ready now, so I decided to move it up as you suggested earlier. Please feel free to move it to any place you find more appropriate, not necessarily the one I chose.

The next step in its development is granular permissions.

As you probably noticed, I chose a bit long name for the plugin because we already have the Firebase plugin. At first, I was going to name it Firestore. But Cloud Firestore is not the only feature this plugin supports. Any thoughts on how we can simplify the plugin name?
Preview my changes here: https://plugins.mavo.io/?storage=https%3A%2F%2Fraw.githubusercontent.com%2FDmitrySharabin%2Fplugins%2Fmaster%2Fplugins.json&plugins-storage=https%3A%2F%2Fgithub.com%2Fmavoweb%2Fplugins%2Fplugins.json