### PR TITLE
Fix for #73

### DIFF
--- a/tinymce/mavo-tinymce.js
+++ b/tinymce/mavo-tinymce.js
@@ -3,7 +3,7 @@
 var parser, serializer;
 
 Mavo.Plugins.register("tinymce", {
-	ready: $.include(self.tinymce, "https://cdn.tinymce.com/4/tinymce.min.js").then(() => {
+	ready: $.include(self.tinymce, "https://cdnjs.cloudflare.com/ajax/libs/tinymce/4.9.11/tinymce.min.js").then(() => {
 		parser = new tinymce.html.DomParser();
 		serializer = new tinymce.html.Serializer();
 	})


### PR DESCRIPTION
I gave another look at the issue. Its main reason is that the corresponding CDN will be turned off on 25 February 2021. So what if we use CDNJS instead? I believe that will solve the issue. There is no warning in the console anymore.

I am not sure whether it's a good idea to migrate to version 5 (what if it'll introduce breaking changes), so I stuck to the latest  4.9.11 version.

I refused the idea to have a self-hosted version of the library because it has many files to host. 😭