### PR TITLE
[markdown] Some improvements

### DIFF
--- a/markdown/mavo-markdown.js
+++ b/markdown/mavo-markdown.js
@@ -135,7 +135,9 @@ Mavo.Elements.register("markdown", {
 						env.editor.disabled = true;
 
 						// Disable the Save button until the upload finishes
-						this.mavo.bar.save?.disabled = true;
+						if (this.mavo.bar.save) {
+							this.mavo.bar.save.disabled = true;
+						}
 
 						const path = this.element.getAttribute("mv-upload-path") || "images";
 						const relative = path + "/" + name;
@@ -164,7 +166,9 @@ Mavo.Elements.register("markdown", {
 							t.selectionStart = t.selectionEnd - image.length;
 						}
 
-						this.mavo.bar.save?.disabled = false;
+						if (this.mavo.bar.save) {
+							this.mavo.bar.save.disabled = false;
+						}
 
 						evt.preventDefault();
 					}

--- a/markdown/mavo-markdown.js
+++ b/markdown/mavo-markdown.js
@@ -135,7 +135,7 @@ Mavo.Elements.register("markdown", {
 						env.editor.disabled = true;
 
 						// Disable the Save button until the upload finishes
-						this.mavo.bar.save.disabled = true;
+						this.mavo.bar.save?.disabled = true;
 
 						const path = this.element.getAttribute("mv-upload-path") || "images";
 						const relative = path + "/" + name;
@@ -164,7 +164,7 @@ Mavo.Elements.register("markdown", {
 							t.selectionStart = t.selectionEnd - image.length;
 						}
 
-						this.mavo.bar.save.disabled = false;
+						this.mavo.bar.save?.disabled = false;
 
 						evt.preventDefault();
 					}

--- a/markdown/mavo-markdown.js
+++ b/markdown/mavo-markdown.js
@@ -109,10 +109,8 @@ Mavo.Elements.register("markdown", {
 		});
 
 		// Image upload
-		const canUpload = Boolean(this.mavo.uploadBackend && self.FileReader);
-
 		env.editor.addEventListener("paste", async evt => {
-			if (canUpload) {
+			if (this.mavo.uploadBackend && self.FileReader) {
 				// Look for the first image in the clipboard
 				const item = Array.from(evt.clipboardData.items).find(item => item.kind == "file" && item.type.indexOf("image/") === 0);
 


### PR DESCRIPTION
1. Move the upload affordance checking, so it lives in one place and not be repeated everywhere uploads via paste are allowed.

2. Try to get the filename of the uploaded image from the clipboard.

3. Disables the Save button until the upload finishes.

4. Replace the selection with the code for the uploaded image and select the inserted code.

5. Replace `env.context` with this.

6. Remove extra spaces.

Thank you very much for your comments on PR #71: I could see it had much more issues than I thought. So I decided to close that PR improve the existing code, and, hopefully, make it better. I believe It hasn't got that PR's issues. 🤞🏻