### PR TITLE
tinymce option: add toolbar config via attribute

### DIFF
--- a/tinymce/README.md
+++ b/tinymce/README.md
@@ -1,1 +1,3 @@
 To use TinyMCE, follow the installation instructions below. Then add `class="tinymce"` to the property that you want to be edited via TinyMCE.
+
+Additionally, you can customize the [tinymce toolbar](https://www.tiny.cloud/docs-4x/configure/editor-appearance/#groupingtoolbarcontrols) that is used for each field. By passing an attribute called `mv-tinymce-toolbar`, you can specify which buttons show on the toolbar, see the [tinymce toolbar docs](https://www.tiny.cloud/docs-4x/advanced/editor-control-identifiers/#toolbarcontrols) for more information. By default the following value is used for the toolbar when nothing is specified: `"styleselect | bold italic | image link | table | bullist numlist"`

--- a/tinymce/mavo-tinymce.js
+++ b/tinymce/mavo-tinymce.js
@@ -24,12 +24,14 @@ Mavo.Elements.register(".tinymce", {
 				return;
 			}
 
+			const toolbarOptions = this.element.getAttribute("data-tinymce-toolbar")
+
 			// Init for the first time
 			tinymce.init({
 				target: this.element,
 				inline: true,
 				menubar: false,
-				toolbar: "styleselect | bold italic | image link | table | bullist numlist",
+				toolbar: toolbarOptions || "styleselect | bold italic | image link | table | bullist numlist",
 				plugins: "image code link table lists media tabfocus"
 			}).then(editors => {
 				this.element.tinymce = editors[0];

--- a/tinymce/mavo-tinymce.js
+++ b/tinymce/mavo-tinymce.js
@@ -24,14 +24,14 @@ Mavo.Elements.register(".tinymce", {
 				return;
 			}
 
-			const toolbarOptions = this.element.getAttribute("data-tinymce-toolbar")
+			const toolbar = this.element.getAttribute("mv-tinymce-toolbar")
 
 			// Init for the first time
 			tinymce.init({
 				target: this.element,
 				inline: true,
 				menubar: false,
-				toolbar: toolbarOptions || "styleselect | bold italic | image link | table | bullist numlist",
+				toolbar: toolbar || "styleselect | bold italic | image link | table | bullist numlist",
 				plugins: "image code link table lists media tabfocus"
 			}).then(editors => {
 				this.element.tinymce = editors[0];


### PR DESCRIPTION
add toolbar config via attribute for #81 

I'm open to different naming of `data-tinymce-toolbar` if you have other ideas. Also need to test this and update documentation but wanted some initial feedback. 
