### PR TITLE
Fix GitHub buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -80,7 +80,7 @@ section[mv-app="plugins"] > div {
         text-decoration: none; }
     .plugin footer .button,
     .plugin footer .github-button,
-    .plugin footer .github-buttons > a,
+    .plugin footer .github-buttons > span,
     .plugin footer iframe {
       margin: 0 .1em; }
     .plugin footer a {

--- a/css/style.scss
+++ b/css/style.scss
@@ -115,7 +115,7 @@ section[mv-app="plugins"] {
 
 		.button,
 		.github-button,
-		.github-buttons > a,
+		.github-buttons > span,
 		iframe {
 			margin: 0 .1em;
 		}

--- a/plugin/index.html
+++ b/plugin/index.html
@@ -69,9 +69,9 @@
 				<a href="https://github.com/[repo]/issues" data-icon="octicon-issue-opened" data-size="large" data-show-count="true" data-count-aria-label="# issues on GitHub" aria-label="Issue [repo] on GitHub">Issues</a>
 				<a href="[github]" data-icon="octicon-star" data-size="large" data-count-href="/[repo]/stargazers" data-show-count="true" data-count-aria-label="# stargazers on GitHub" aria-label="Star [repo] on GitHub">Star</a>
 			</div>
-			<div mv-if="!repo">
-				<a class="github-button" href="http://github.com/mavoweb/plugins/tree/master/[id]" data-icon="octicon-mark-github" data-size="large" aria-label="Plugin files on GitHub">Files</a>
-				<a href="http://github.com/mavoweb/plugins/issues?q=[id]%20in%3Atitle%20" class="bugs button">Issues</a>
+			<div mv-if="!repo" class="github-buttons">
+				<a href="http://github.com/mavoweb/plugins/tree/master/[id]" data-icon="octicon-mark-github" data-size="large" aria-label="Plugin files on GitHub">Files</a>
+				<a href="http://github.com/mavoweb/plugins/issues?q=[id]%20in%3Atitle%20" data-icon="octicon-issue-opened" data-size="large" data-show-count="false">Issues</a>
 			</div>
 		</footer>
 	</article>

--- a/plugin/index.tpl.html
+++ b/plugin/index.tpl.html
@@ -43,9 +43,9 @@
 				<a href="https://github.com/[repo]/issues" data-icon="octicon-issue-opened" data-size="large" data-show-count="true" data-count-aria-label="# issues on GitHub" aria-label="Issue [repo] on GitHub">Issues</a>
 				<a href="[github]" data-icon="octicon-star" data-size="large" data-count-href="/[repo]/stargazers" data-show-count="true" data-count-aria-label="# stargazers on GitHub" aria-label="Star [repo] on GitHub">Star</a>
 			</div>
-			<div mv-if="!repo">
-				<a class="github-button" href="http://github.com/mavoweb/plugins/tree/master/[id]" data-icon="octicon-mark-github" data-size="large" aria-label="Plugin files on GitHub">Files</a>
-				<a href="http://github.com/mavoweb/plugins/issues?q=[id]%20in%3Atitle%20" class="bugs button">Issues</a>
+			<div mv-if="!repo" class="github-buttons">
+				<a href="http://github.com/mavoweb/plugins/tree/master/[id]" data-icon="octicon-mark-github" data-size="large" aria-label="Plugin files on GitHub">Files</a>
+				<a href="http://github.com/mavoweb/plugins/issues?q=[id]%20in%3Atitle%20" data-icon="octicon-issue-opened" data-size="large" data-show-count="false">Issues</a>
 			</div>
 		</footer>
 	</article>


### PR DESCRIPTION
Now, these buttons work as they should.

## Before
<img width="784" alt="Screen Shot 2021-06-27 at 15 02 53" src="https://user-images.githubusercontent.com/9166277/123543777-d96faa80-d758-11eb-8f83-df96e498ed2f.png">

## After
<img width="762" alt="Screen Shot 2021-06-27 at 14 56 11" src="https://user-images.githubusercontent.com/9166277/123543593-fc4d8f00-d757-11eb-92c8-e570a1a17482.png">
