### PR TITLE
Add tinymce extended valid elements attribute

### DIFF
--- a/tinymce/README.md
+++ b/tinymce/README.md
@@ -1,3 +1,5 @@
 To use TinyMCE, follow the installation instructions below. Then add `class="tinymce"` to the property that you want to be edited via TinyMCE.
 
 Additionally, you can customize the [tinymce toolbar](https://www.tiny.cloud/docs-4x/configure/editor-appearance/#groupingtoolbarcontrols) that is used for each field. By passing an attribute called `mv-tinymce-toolbar`, you can specify which buttons show on the toolbar, see the [tinymce toolbar docs](https://www.tiny.cloud/docs-4x/advanced/editor-control-identifiers/#toolbarcontrols) for more information. By default the following value is used for the toolbar when nothing is specified: `"styleselect | bold italic | image link | table | bullist numlist"`
+
+You can also specify additional valid elements using the `mv-tinymce-extended-valid-elements` attribute. This allows you to include elements that TinyMCE might otherwise strip out: `mv-tinymce-extended-valid-elements="span,div[*],p[*]"`

--- a/tinymce/mavo-tinymce.js
+++ b/tinymce/mavo-tinymce.js
@@ -114,6 +114,7 @@ Mavo.Elements.register(".tinymce", {
 			}
 
 			const toolbar = this.element.getAttribute("mv-tinymce-toolbar")?.trim() || defaultToolbar;
+			const extendedValidElements = this.element.getAttribute("mv-tinymce-extended-valid-elements")?.trim() || '';
 
 			// Parse the passed-in toolbar
 			const groups = toolbar.split("|").filter(g => g.length);
@@ -143,7 +144,8 @@ Mavo.Elements.register(".tinymce", {
 				inline: true,
 				menubar: false,
 				toolbar,
-				plugins: Array.from(plugins).join(" ") // "plugin plugin ... plugin"
+				plugins: Array.from(plugins).join(" "), // "plugin plugin ... plugin"
+				extended_valid_elements: extendedValidElements
 			}).then(editors => {
 				this.element.tinymce = editors[0];
 


### PR DESCRIPTION
In my case tinyMCE is deleting `span` HTML tag. I'd like to have option to use `extended_valid_elements` configuration option.